### PR TITLE
Fix: Grant write permissions for deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build-and-deploy:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR adds the necessary 'contents: write' permission to the GitHub Actions workflow to allow the deployment job to push to the gh-pages branch.