### PR TITLE
Fix: Add homepage for GitHub Pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "sequencer64",
   "version": "0.1.0",
   "private": true,
+  "homepage": "https://shepsci.github.io/gemini-sequencer",
   "dependencies": {
     "@reduxjs/toolkit": "^1.5.0",
     "@testing-library/jest-dom": "^5.11.9",


### PR DESCRIPTION
This PR adds the 'homepage' field to package.json to ensure the deployed application can correctly locate its assets on GitHub Pages.