### PR TITLE
Fix: Use HashRouter for GitHub Pages

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -26,7 +26,7 @@ export default function App() {
             <Subscriptions />
         </Provider>
       </ErrorBoundary>
-    </BrowserRouter>
+    </HashRouter>
   );
 }
 


### PR DESCRIPTION
This PR replaces BrowserRouter with HashRouter to ensure correct routing on GitHub Pages.